### PR TITLE
Tweaks and fixes (3)

### DIFF
--- a/dist/add-markers.js
+++ b/dist/add-markers.js
@@ -439,7 +439,7 @@ Fliplet.InteractiveMap.component('add-markers', {
           marker: options.existingMarker.vars
         });
         $('#' + options.id).addClass('active');
-      } else {
+      } else if (this.selectedMarkerData && this.selectedMarkerData.marker) {
         var markersLength = this.tappedMarkerId || this.flPanZoomInstances[this.selectedMarkerData.map.id].markers.getAll().length;
         markerElem = $("<div id='" + this.selectedMarkerData.marker.id + "' class='marker' data-name='" + this.selectedMarkerData.marker.data.name + "' style='left: -15px; top: -15px; position: absolute; font-size: " + this.selectedMarkerData.marker.data.size + ";'><i class='" + this.selectedMarkerData.marker.data.icon + "' style='color: " + this.selectedMarkerData.marker.data.color + "; font-size: " + this.selectedMarkerData.marker.data.size + ";'></i><div class='active-state'><i class='" + this.selectedMarkerData.marker.data.icon + "' style='color: " + this.selectedMarkerData.marker.data.color + ";'></i></div></div>");
         this.markerElemHandler = new Hammer(markerElem.get(0));
@@ -451,6 +451,27 @@ Fliplet.InteractiveMap.component('add-markers', {
         })]);
         $('#marker-' + markersLength).addClass('active');
         this.tappedMarkerId = undefined;
+      } else {
+        return Fliplet.Modal.confirm({
+          title: 'Add a new marker',
+          message: '<p>You have no markers to place on the map, do you want to create one now?</p>',
+          buttons: {
+            confirm: {
+              label: 'Create marker',
+              className: 'btn-primary'
+            },
+            cancel: {
+              label: 'Cancel',
+              className: 'btn-default'
+            }
+          }
+        }).then(function (result) {
+          if (!result) {
+            return;
+          }
+
+          return _this5.addNewMarker(options);
+        });
       }
 
       this.markerElemHandler.on('tap', this.onMarkerHandler);
@@ -575,7 +596,7 @@ Fliplet.InteractiveMap.component('add-markers', {
       var data = this.cleanData();
       this.dataSourceConnection.commit(data);
     },
-    addNewMarker: function addNewMarker() {
+    addNewMarker: function addNewMarker(options) {
       var _this11 = this;
 
       var newObj = {};

--- a/dist/add-markers.js
+++ b/dist/add-markers.js
@@ -163,7 +163,7 @@ Fliplet.InteractiveMap.component('add-markers', {
       dataSourceId: this.markersDataSourceId,
       dataWasChanged: this.changedDataSource,
       dataSourceConnection: undefined,
-      flPanZoomInstance: null,
+      flPanZoomInstances: {},
       pzElement: undefined,
       pzHandler: undefined,
       markerElemHandler: undefined,
@@ -296,11 +296,11 @@ Fliplet.InteractiveMap.component('add-markers', {
       this.confirmName(index, true);
     },
     deleteMarker: function deleteMarker(index) {
-      var markers = this.flPanZoomInstance.markers.getAll();
+      var markers = this.flPanZoomInstances[this.selectedMarkerData.map.id].markers.getAll();
       var markerId = $('.map-wrapper-holder').find('.marker[data-name="' + this.mappedMarkerData[index].data.name + '"]').attr('id');
 
       if (markerId) {
-        this.flPanZoomInstance.markers.remove(markerId, {
+        this.flPanZoomInstances[this.selectedMarkerData.map.id].markers.remove(markerId, {
           keepInDom: false
         });
       }
@@ -359,7 +359,6 @@ Fliplet.InteractiveMap.component('add-markers', {
       }
 
       var mapName = this.mappedMarkerData[this.activeMarker].data.map;
-      this.imageLoaded = false;
       this.selectedMarkerData.marker = this.mappedMarkerData[this.activeMarker];
       this.selectedMarkerData.map = _.find(this.widgetData.maps, {
         name: mapName
@@ -371,26 +370,31 @@ Fliplet.InteractiveMap.component('add-markers', {
         this.saveDebounced();
       }
 
-      if (this.flPanZoomInstance) {
-        this.detachEventHandler();
-        this.flPanZoomInstance = null;
+      this.pzElement = $('#map-' + this.selectedMarkerData.map.id);
+
+      if (_.isEmpty(this.flPanZoomInstances) || !this.flPanZoomInstances[this.selectedMarkerData.map.id]) {
+        this.imageLoaded = false;
+        this.flPanZoomInstances[this.selectedMarkerData.map.id] = Fliplet.UI.PanZoom.create(this.pzElement, {
+          maxZoom: 4,
+          zoomStep: 0.25,
+          doubleTapZoom: 3,
+          animDuration: 0.1,
+          tapMarkerToActivate: false
+        });
+        this.pzHandler = new Hammer(this.pzElement.get(0));
+        this.attachEventHandler();
+      } else {
+        this.flPanZoomInstances[this.selectedMarkerData.map.id].markers.removeAll();
       }
 
-      this.pzElement = $('#map-' + this.selectedMarkerData.map.id);
-      this.flPanZoomInstance = Fliplet.UI.PanZoom.create(this.pzElement, {
-        maxZoom: 4,
-        zoomStep: 0.25,
-        doubleTapZoom: 3,
-        animDuration: 0.1,
-        tapMarkerToActivate: false
-      });
-      this.flPanZoomInstance.on('mapImageLoaded', function () {
+      this.flPanZoomInstances[this.selectedMarkerData.map.id].on('mapImageLoaded', function () {
         _this4.imageLoaded = true;
       });
-      this.pzHandler = new Hammer(this.pzElement.get(0));
-      this.addMarkers(true);
-      this.attachEventHandler();
-      this.selectPinchMarker();
+
+      if (this.mappedMarkerData.length) {
+        this.addMarkers(true);
+        this.selectPinchMarker();
+      }
     },
     removeMarkers: function removeMarkers() {
       $(this.selector).find('.marker').remove();
@@ -406,12 +410,12 @@ Fliplet.InteractiveMap.component('add-markers', {
         this.removeMarkers();
         this.mappedMarkerData.forEach(function (marker, index) {
           if (marker.data.map === _this5.selectedMarkerData.map.name) {
-            var markersLength = _this5.flPanZoomInstance.markers.getAll().length;
+            var markersLength = _this5.flPanZoomInstances[_this5.selectedMarkerData.map.id].markers.getAll().length;
 
             markerElem = $("<div id='" + marker.id + "' class='marker' data-name='" + marker.data.name + "' style='left: -15px; top: -15px; position: absolute; font-size: " + marker.data.size + ";'><i class='" + marker.data.icon + "' style='color: " + marker.data.color + "; font-size: " + marker.data.size + ";'></i><div class='active-state'><i class='" + marker.data.icon + "' style='color: " + marker.data.color + ";'></i></div></div>");
             _this5.markerElemHandler = new Hammer(markerElem.get(0));
 
-            _this5.flPanZoomInstance.markers.set([Fliplet.UI.PanZoom.Markers.create(markerElem, {
+            _this5.flPanZoomInstances[_this5.selectedMarkerData.map.id].markers.set([Fliplet.UI.PanZoom.Markers.create(markerElem, {
               x: marker.data.positionX,
               y: marker.data.positionY,
               name: marker.data.name,
@@ -436,10 +440,10 @@ Fliplet.InteractiveMap.component('add-markers', {
         });
         $('#' + options.id).addClass('active');
       } else {
-        var markersLength = this.tappedMarkerId || this.flPanZoomInstance.markers.getAll().length;
+        var markersLength = this.tappedMarkerId || this.flPanZoomInstances[this.selectedMarkerData.map.id].markers.getAll().length;
         markerElem = $("<div id='" + this.selectedMarkerData.marker.id + "' class='marker' data-name='" + this.selectedMarkerData.marker.data.name + "' style='left: -15px; top: -15px; position: absolute; font-size: " + this.selectedMarkerData.marker.data.size + ";'><i class='" + this.selectedMarkerData.marker.data.icon + "' style='color: " + this.selectedMarkerData.marker.data.color + "; font-size: " + this.selectedMarkerData.marker.data.size + ";'></i><div class='active-state'><i class='" + this.selectedMarkerData.marker.data.icon + "' style='color: " + this.selectedMarkerData.marker.data.color + ";'></i></div></div>");
         this.markerElemHandler = new Hammer(markerElem.get(0));
-        this.flPanZoomInstance.markers.set([Fliplet.UI.PanZoom.Markers.create(markerElem, {
+        this.flPanZoomInstances[this.selectedMarkerData.map.id].markers.set([Fliplet.UI.PanZoom.Markers.create(markerElem, {
           x: options.x,
           y: options.y,
           name: this.selectedMarkerData.marker.data.name,
@@ -475,7 +479,7 @@ Fliplet.InteractiveMap.component('add-markers', {
     onTapHandler: function onTapHandler(e) {
       var _this7 = this;
 
-      var markers = this.flPanZoomInstance.markers.getAll();
+      var markers = this.flPanZoomInstances[this.selectedMarkerData.map.id].markers.getAll();
 
       if (!$(e.target).hasClass('marker')) {
         // Find a marker
@@ -495,8 +499,8 @@ Fliplet.InteractiveMap.component('add-markers', {
         var elemPosX = clientRect.left;
         var elemPosY = clientRect.top;
         var center = e.center;
-        var x = (center.x - elemPosX) / (this.flPanZoomInstance.getBaseZoom() * this.flPanZoomInstance.getCurrentZoom());
-        var y = (center.y - elemPosY) / (this.flPanZoomInstance.getBaseZoom() * this.flPanZoomInstance.getCurrentZoom());
+        var x = (center.x - elemPosX) / (this.flPanZoomInstances[this.selectedMarkerData.map.id].getBaseZoom() * this.flPanZoomInstances[this.selectedMarkerData.map.id].getCurrentZoom());
+        var y = (center.y - elemPosY) / (this.flPanZoomInstances[this.selectedMarkerData.map.id].getBaseZoom() * this.flPanZoomInstances[this.selectedMarkerData.map.id].getCurrentZoom());
         this.addMarkers(false, {
           x: x,
           y: y,
@@ -506,11 +510,11 @@ Fliplet.InteractiveMap.component('add-markers', {
       }
     },
     onMarkerHandler: function onMarkerHandler(e) {
-      var markers = this.flPanZoomInstance.markers.getAll();
+      var markers = this.flPanZoomInstances[this.selectedMarkerData.map.id].markers.getAll();
       var markerId = $(e.target).attr('id');
 
       if (markerId && markerId === this.selectedMarkerData.marker.id) {
-        this.flPanZoomInstance.markers.remove(markerId, true);
+        this.flPanZoomInstances[this.selectedMarkerData.map.id].markers.remove(markerId, true);
       }
     },
     selectPinchMarker: function selectPinchMarker() {
@@ -519,7 +523,7 @@ Fliplet.InteractiveMap.component('add-markers', {
       // Remove any active marker
       $('.marker').removeClass('active'); // Get markers
 
-      var markers = this.flPanZoomInstance.markers.getAll(); // Store first marker
+      var markers = this.flPanZoomInstances[this.selectedMarkerData.map.id].markers.getAll(); // Store first marker
 
       var marker = markers[0]; // Find the new selected marker from flPanZoomInstance
 
@@ -588,8 +592,8 @@ Fliplet.InteractiveMap.component('add-markers', {
       var image = $('#map-' + this.selectedMarkerData.map.id).find('img')[0];
       var rect = image.getBoundingClientRect();
       var position = {
-        x: rect.width * 0.5 / (this.flPanZoomInstance.getBaseZoom() * this.flPanZoomInstance.getCurrentZoom()),
-        y: rect.height * 0.5 / (this.flPanZoomInstance.getBaseZoom() * this.flPanZoomInstance.getCurrentZoom())
+        x: rect.width * 0.5 / (this.flPanZoomInstances[this.selectedMarkerData.map.id].getBaseZoom() * this.flPanZoomInstances[this.selectedMarkerData.map.id].getCurrentZoom()),
+        y: rect.height * 0.5 / (this.flPanZoomInstances[this.selectedMarkerData.map.id].getBaseZoom() * this.flPanZoomInstances[this.selectedMarkerData.map.id].getCurrentZoom())
       };
       newObj[this.markerNameColumn] = "New marker ".concat(markerLength + 1);
       newObj[this.markerMapColumn] = mapName;

--- a/js/interface/add-markers.js
+++ b/js/interface/add-markers.js
@@ -316,13 +316,34 @@ Fliplet.InteractiveMap.component('add-markers', {
           marker: options.existingMarker.vars
         })
         $('#' + options.id).addClass('active')
-      } else {
+      } else if (this.selectedMarkerData && this.selectedMarkerData.marker) {
         const markersLength = this.tappedMarkerId || this.flPanZoomInstances[this.selectedMarkerData.map.id].markers.getAll().length
         markerElem = $("<div id='" + this.selectedMarkerData.marker.id + "' class='marker' data-name='" + this.selectedMarkerData.marker.data.name + "' style='left: -15px; top: -15px; position: absolute; font-size: " + this.selectedMarkerData.marker.data.size + ";'><i class='" + this.selectedMarkerData.marker.data.icon + "' style='color: " + this.selectedMarkerData.marker.data.color + "; font-size: " + this.selectedMarkerData.marker.data.size + ";'></i><div class='active-state'><i class='" + this.selectedMarkerData.marker.data.icon + "' style='color: " + this.selectedMarkerData.marker.data.color + ";'></i></div></div>")
         this.markerElemHandler = new Hammer(markerElem.get(0))
         this.flPanZoomInstances[this.selectedMarkerData.map.id].markers.set([Fliplet.UI.PanZoom.Markers.create(markerElem, { x: options.x, y: options.y, name: this.selectedMarkerData.marker.data.name, id: this.selectedMarkerData.marker.id })])
         $('#marker-' + markersLength).addClass('active')
         this.tappedMarkerId = undefined
+      } else {
+        return Fliplet.Modal.confirm({
+          title: 'Add a new marker',
+          message: '<p>You have no markers to place on the map, do you want to create one now?</p>',
+          buttons: {
+            confirm: {
+              label: 'Create marker',
+              className: 'btn-primary'
+            },
+            cancel: {
+              label: 'Cancel',
+              className: 'btn-default'
+            }
+          }
+        }).then((result) => {
+          if (!result) {
+            return
+          }
+
+          return this.addNewMarker(options)
+        })
       }
       
       this.markerElemHandler.on('tap', this.onMarkerHandler)
@@ -437,7 +458,7 @@ Fliplet.InteractiveMap.component('add-markers', {
       const data = this.cleanData()
       this.dataSourceConnection.commit(data)
     },
-    addNewMarker() {
+    addNewMarker(options) {
       const newObj = {}
       const markerLength = this.mappedMarkerData.length
       let mapName

--- a/js/interface/add-markers.js
+++ b/js/interface/add-markers.js
@@ -57,7 +57,7 @@ Fliplet.InteractiveMap.component('add-markers', {
       dataSourceId: this.markersDataSourceId,
       dataWasChanged: this.changedDataSource,
       dataSourceConnection: undefined,
-      flPanZoomInstance: null,
+      flPanZoomInstances: {},
       pzElement: undefined,
       pzHandler: undefined,
       markerElemHandler: undefined,
@@ -183,13 +183,13 @@ Fliplet.InteractiveMap.component('add-markers', {
       this.confirmName(index, true)
     },
     deleteMarker(index) {
-      const markers = this.flPanZoomInstance.markers.getAll()
+      const markers = this.flPanZoomInstances[this.selectedMarkerData.map.id].markers.getAll()
       const markerId = $('.map-wrapper-holder')
         .find('.marker[data-name="' + this.mappedMarkerData[index].data.name + '"]')
         .attr('id')
         
       if (markerId) {
-        this.flPanZoomInstance.markers.remove(markerId, {keepInDom: false})
+        this.flPanZoomInstances[this.selectedMarkerData.map.id].markers.remove(markerId, {keepInDom: false})
       }
 
       this.mappedMarkerData.splice(index, 1)
@@ -248,7 +248,6 @@ Fliplet.InteractiveMap.component('add-markers', {
       }
 
       const mapName = this.mappedMarkerData[this.activeMarker].data.map
-      this.imageLoaded = false
       this.selectedMarkerData.marker = this.mappedMarkerData[this.activeMarker]
       this.selectedMarkerData.map = _.find(this.widgetData.maps, { name: mapName })
       // If the map doesn't exist anymore set the first one in the list
@@ -258,30 +257,33 @@ Fliplet.InteractiveMap.component('add-markers', {
         this.saveDebounced()
       }
 
-      if (this.flPanZoomInstance) {
-        this.detachEventHandler()
-        this.flPanZoomInstance = null
-      }
-
       this.pzElement = $('#map-' + this.selectedMarkerData.map.id)
 
-      this.flPanZoomInstance = Fliplet.UI.PanZoom.create(this.pzElement, {
-        maxZoom: 4,
-        zoomStep: 0.25,
-        doubleTapZoom: 3,
-        animDuration: 0.1,
-        tapMarkerToActivate: false
-      })
+      if (_.isEmpty(this.flPanZoomInstances) || !this.flPanZoomInstances[this.selectedMarkerData.map.id]) {
+        this.imageLoaded = false
 
-      this.flPanZoomInstance.on('mapImageLoaded', () => {
+        this.flPanZoomInstances[this.selectedMarkerData.map.id] = Fliplet.UI.PanZoom.create(this.pzElement, {
+          maxZoom: 4,
+          zoomStep: 0.25,
+          doubleTapZoom: 3,
+          animDuration: 0.1,
+          tapMarkerToActivate: false
+        })
+
+        this.pzHandler = new Hammer(this.pzElement.get(0))
+        this.attachEventHandler()
+      } else {
+        this.flPanZoomInstances[this.selectedMarkerData.map.id].markers.removeAll()
+      }
+
+      this.flPanZoomInstances[this.selectedMarkerData.map.id].on('mapImageLoaded', () => {
         this.imageLoaded = true
       })
 
-      this.pzHandler = new Hammer(this.pzElement.get(0))
-
-      this.addMarkers(true)
-      this.attachEventHandler()
-      this.selectPinchMarker()
+      if (this.mappedMarkerData.length) {
+        this.addMarkers(true)
+        this.selectPinchMarker()
+      }
     },
     removeMarkers() {
       $(this.selector).find('.marker').remove()
@@ -296,10 +298,10 @@ Fliplet.InteractiveMap.component('add-markers', {
 
         this.mappedMarkerData.forEach((marker, index) => {
           if (marker.data.map === this.selectedMarkerData.map.name) {
-            const markersLength = this.flPanZoomInstance.markers.getAll().length
+            const markersLength = this.flPanZoomInstances[this.selectedMarkerData.map.id].markers.getAll().length
             markerElem = $("<div id='" + marker.id + "' class='marker' data-name='" + marker.data.name + "' style='left: -15px; top: -15px; position: absolute; font-size: " + marker.data.size + ";'><i class='" + marker.data.icon + "' style='color: " + marker.data.color + "; font-size: " + marker.data.size + ";'></i><div class='active-state'><i class='" + marker.data.icon + "' style='color: " + marker.data.color + ";'></i></div></div>")
             this.markerElemHandler = new Hammer(markerElem.get(0))
-            this.flPanZoomInstance.markers.set([Fliplet.UI.PanZoom.Markers.create(markerElem, { x: marker.data.positionX, y: marker.data.positionY, name: marker.data.name, id: marker.id })])
+            this.flPanZoomInstances[this.selectedMarkerData.map.id].markers.set([Fliplet.UI.PanZoom.Markers.create(markerElem, { x: marker.data.positionX, y: marker.data.positionY, name: marker.data.name, id: marker.id })])
             this.markerElemHandler.on('tap', this.onMarkerHandler)
           }
         })
@@ -315,10 +317,10 @@ Fliplet.InteractiveMap.component('add-markers', {
         })
         $('#' + options.id).addClass('active')
       } else {
-        const markersLength = this.tappedMarkerId || this.flPanZoomInstance.markers.getAll().length
+        const markersLength = this.tappedMarkerId || this.flPanZoomInstances[this.selectedMarkerData.map.id].markers.getAll().length
         markerElem = $("<div id='" + this.selectedMarkerData.marker.id + "' class='marker' data-name='" + this.selectedMarkerData.marker.data.name + "' style='left: -15px; top: -15px; position: absolute; font-size: " + this.selectedMarkerData.marker.data.size + ";'><i class='" + this.selectedMarkerData.marker.data.icon + "' style='color: " + this.selectedMarkerData.marker.data.color + "; font-size: " + this.selectedMarkerData.marker.data.size + ";'></i><div class='active-state'><i class='" + this.selectedMarkerData.marker.data.icon + "' style='color: " + this.selectedMarkerData.marker.data.color + ";'></i></div></div>")
         this.markerElemHandler = new Hammer(markerElem.get(0))
-        this.flPanZoomInstance.markers.set([Fliplet.UI.PanZoom.Markers.create(markerElem, { x: options.x, y: options.y, name: this.selectedMarkerData.marker.data.name, id: this.selectedMarkerData.marker.id })])
+        this.flPanZoomInstances[this.selectedMarkerData.map.id].markers.set([Fliplet.UI.PanZoom.Markers.create(markerElem, { x: options.x, y: options.y, name: this.selectedMarkerData.marker.data.name, id: this.selectedMarkerData.marker.id })])
         $('#marker-' + markersLength).addClass('active')
         this.tappedMarkerId = undefined
       }
@@ -345,7 +347,7 @@ Fliplet.InteractiveMap.component('add-markers', {
       this.pzHandler.off('tap', this.onTapHandler)
     },
     onTapHandler(e) {
-      const markers = this.flPanZoomInstance.markers.getAll()
+      const markers = this.flPanZoomInstances[this.selectedMarkerData.map.id].markers.getAll()
 
       if (!$(e.target).hasClass('marker')) {
         // Find a marker
@@ -363,8 +365,8 @@ Fliplet.InteractiveMap.component('add-markers', {
         const elemPosX = clientRect.left
         const elemPosY = clientRect.top
         const center = e.center
-        const x = (center.x - elemPosX) / (this.flPanZoomInstance.getBaseZoom() * this.flPanZoomInstance.getCurrentZoom())
-        const y = (center.y - elemPosY) / (this.flPanZoomInstance.getBaseZoom() * this.flPanZoomInstance.getCurrentZoom())
+        const x = (center.x - elemPosX) / (this.flPanZoomInstances[this.selectedMarkerData.map.id].getBaseZoom() * this.flPanZoomInstances[this.selectedMarkerData.map.id].getCurrentZoom())
+        const y = (center.y - elemPosY) / (this.flPanZoomInstances[this.selectedMarkerData.map.id].getBaseZoom() * this.flPanZoomInstances[this.selectedMarkerData.map.id].getCurrentZoom())
 
         this.addMarkers(false, {
           x: x,
@@ -375,18 +377,18 @@ Fliplet.InteractiveMap.component('add-markers', {
       }
     },
     onMarkerHandler(e) {
-      const markers = this.flPanZoomInstance.markers.getAll()
+      const markers = this.flPanZoomInstances[this.selectedMarkerData.map.id].markers.getAll()
       const markerId = $(e.target).attr('id')
       
       if (markerId && markerId === this.selectedMarkerData.marker.id) {
-        this.flPanZoomInstance.markers.remove(markerId, true)
+        this.flPanZoomInstances[this.selectedMarkerData.map.id].markers.remove(markerId, true)
       }
     },
     selectPinchMarker() {
       // Remove any active marker
       $('.marker').removeClass('active')
       // Get markers
-      const markers = this.flPanZoomInstance.markers.getAll()
+      const markers = this.flPanZoomInstances[this.selectedMarkerData.map.id].markers.getAll()
       // Store first marker
       const marker = markers[0]
 
@@ -449,8 +451,8 @@ Fliplet.InteractiveMap.component('add-markers', {
       const image = $('#map-' + this.selectedMarkerData.map.id).find('img')[0]
       const rect = image.getBoundingClientRect()
       const position = {
-        x: (rect.width * 0.5) / (this.flPanZoomInstance.getBaseZoom() * this.flPanZoomInstance.getCurrentZoom()),
-        y: (rect.height * 0.5) / (this.flPanZoomInstance.getBaseZoom() * this.flPanZoomInstance.getCurrentZoom())
+        x: (rect.width * 0.5) / (this.flPanZoomInstances[this.selectedMarkerData.map.id].getBaseZoom() * this.flPanZoomInstances[this.selectedMarkerData.map.id].getCurrentZoom()),
+        y: (rect.height * 0.5) / (this.flPanZoomInstances[this.selectedMarkerData.map.id].getBaseZoom() * this.flPanZoomInstances[this.selectedMarkerData.map.id].getCurrentZoom())
       }
 
       newObj[this.markerNameColumn] = `New marker ${markerLength + 1}`

--- a/js/libs/build.js
+++ b/js/libs/build.js
@@ -17,9 +17,8 @@ Fliplet.Widget.instance('interactive-map', function(widgetData) {
         markersData: undefined,
         mappedMarkerData: [],
         searchMarkerData: undefined,
-        flPanZoomInstance: null,
+        flPanZoomInstances: {},
         pzElement: undefined,
-        pzHandler: undefined,
         markerElemHandler: undefined,
         activeMap: 0,
         activeMarker: 0,
@@ -85,31 +84,30 @@ Fliplet.Widget.instance('interactive-map', function(widgetData) {
         return newMarkerData
       },
       setupFlPanZoom() {
-        this.imageLoaded = false
         this.selectedMapData = this.maps[this.activeMap]
         this.selectedMarkerData = this.mappedMarkerData[this.activeMarker]
           ? this.mappedMarkerData[this.activeMarker].data
           : undefined
         this.selectedMarkerToggle = !!this.selectedMarkerData
 
-        if (this.flPanZoomInstance) {
-          this.flPanZoomInstance = null
-        }
-
         this.pzElement = $('#map-' + this.selectedMapData.id)
 
-        this.flPanZoomInstance = Fliplet.UI.PanZoom.create(this.pzElement, {
-          maxZoom: 4,
-          zoomStep: 0.25,
-          doubleTapZoom: 3,
-          animDuration: 0.1
-        })
+        if (_.isEmpty(this.flPanZoomInstances) || !this.flPanZoomInstances[this.selectedMapData.id]) {
+          this.imageLoaded = false
 
-        this.flPanZoomInstance.on('mapImageLoaded', () => {
+          this.flPanZoomInstances[this.selectedMapData.id] = Fliplet.UI.PanZoom.create(this.pzElement, {
+            maxZoom: 4,
+            zoomStep: 0.25,
+            doubleTapZoom: 3,
+            animDuration: 0.1
+          })
+        } else {
+          this.flPanZoomInstances[this.selectedMapData.id].markers.removeAll()
+        }
+
+        this.flPanZoomInstances[this.selectedMapData.id].on('mapImageLoaded', () => {
           this.imageLoaded = true
         })
-
-        this.pzHandler = new Hammer(this.pzElement.get(0))
 
         if (this.mappedMarkerData.length) {
           this.addMarkers(true)
@@ -120,7 +118,7 @@ Fliplet.Widget.instance('interactive-map', function(widgetData) {
         // Remove any active marker
         $('.marker').removeClass('active')
         // Get markers
-        const markers = this.flPanZoomInstance.markers.getAll()
+        const markers = this.flPanZoomInstances[this.selectedMapData.id].markers.getAll()
 
         if (!markers.length) {
           return
@@ -143,20 +141,18 @@ Fliplet.Widget.instance('interactive-map', function(widgetData) {
         }
       },
       addMarkers(fromLoad, options) {
-        this.flPanZoomInstance.markers.removeAll()
-
         this.mappedMarkerData.forEach((marker, index) => {
           if (marker.data.map === this.selectedMapData.name) {
             const markerElem = $("<div id='" + marker.id + "' class='marker' data-name='" + marker.data.name + "' style='left: -15px; top: -15px; position: absolute; font-size: " + marker.data.size + ";'><i class='" + marker.data.icon + "' style='color: " + marker.data.color + "; font-size: " + marker.data.size + ";'></i><div class='active-state'><i class='" + marker.data.icon + "' style='color: " + marker.data.color + ";'></i></div></div>")
 
             this.markerElemHandler = new Hammer(markerElem.get(0))
-            this.flPanZoomInstance.markers.set([Fliplet.UI.PanZoom.Markers.create(markerElem, { x: marker.data.positionX, y: marker.data.positionY, name: marker.data.name, id: marker.id })])
+            this.flPanZoomInstances[this.selectedMapData.id].markers.set([Fliplet.UI.PanZoom.Markers.create(markerElem, { x: marker.data.positionX, y: marker.data.positionY, name: marker.data.name, id: marker.id })])
             this.markerElemHandler.on('tap', this.onMarkerHandler)
           }
         })
       },
       onMarkerHandler(e) {
-        const markers = this.flPanZoomInstance.markers.getAll()
+        const markers = this.flPanZoomInstances[this.selectedMapData.id].markers.getAll()
         const id = $(e.target).attr('id')
         const marker = _.find(markers, (o) => { return o.vars.id == id })
         this.activeMarker = _.findIndex(this.mappedMarkerData, (o) => { return o.id == marker.vars.id })


### PR DESCRIPTION
**Note:** This needs (https://github.com/Fliplet/fliplet-widget-interactive-map/pull/12) merged before reviewing

- Refactor how instances of Fliplet.UI.PanZoom are used - Instead of destroy them we now reuse them
- Allow users to add their initial marker by clicking on the map (Settings)