### PR TITLE
Fixes bad coordinates on very big images

### DIFF
--- a/dist/map-panel.js
+++ b/dist/map-panel.js
@@ -153,15 +153,11 @@ Fliplet.InteractiveMap.component('map-panel', {
       });
       window.filePickerProvider.then(function (result) {
         var imageUrl = result.data[0].url;
+        var pattern = /[?&]size=/;
 
-        if (imageUrl.indexOf('?size=') === -1 && imageUrl.indexOf('&size=') === -1) {
+        if (!pattern.test(url)) {
           var params = imageUrl.substring(1).split('?');
-
-          if (params.length > 1) {
-            imageUrl = imageUrl + '&size=large';
-          } else {
-            imageUrl = imageUrl + '?size=large';
-          }
+          imageUrl += (params.length > 1 ? '&' : '?') + 'size=large';
         }
 
         result.data[0].url = imageUrl;

--- a/dist/map-panel.js
+++ b/dist/map-panel.js
@@ -152,7 +152,19 @@ Fliplet.InteractiveMap.component('map-panel', {
         }
       });
       window.filePickerProvider.then(function (result) {
-        result.data[0].url = result.data[0].url + '?size=large';
+        var imageUrl = result.data[0].url;
+
+        if (imageUrl.indexOf('?size=') === -1 && imageUrl.indexOf('&size=') === -1) {
+          var params = imageUrl.substring(1).split('?');
+
+          if (params.length > 1) {
+            imageUrl = imageUrl + '&size=large';
+          } else {
+            imageUrl = imageUrl + '?size=large';
+          }
+        }
+
+        result.data[0].url = imageUrl;
         _this.image = result.data[0];
 
         _this.onInputData(true);

--- a/dist/map-panel.js
+++ b/dist/map-panel.js
@@ -152,6 +152,7 @@ Fliplet.InteractiveMap.component('map-panel', {
         }
       });
       window.filePickerProvider.then(function (result) {
+        result.data[0].url = result.data[0].url + '?size=large';
         _this.image = result.data[0];
 
         _this.onInputData(true);

--- a/js/interface/map-panel.js
+++ b/js/interface/map-panel.js
@@ -56,15 +56,11 @@ Fliplet.InteractiveMap.component('map-panel', {
 
       window.filePickerProvider.then((result) => {
         let imageUrl = result.data[0].url
+        const pattern = /[?&]size=/
 
-        if (imageUrl.indexOf('?size=') === -1 && imageUrl.indexOf('&size=') === -1) {
+        if (!pattern.test(url)) {
           const params = imageUrl.substring(1).split('?');
-          
-          if (params.length > 1) {
-            imageUrl = imageUrl + '&size=large'
-          } else {
-            imageUrl = imageUrl + '?size=large'
-          }
+          imageUrl += (params.length > 1 ? '&' : '?') + 'size=large'
         }
 
         result.data[0].url = imageUrl

--- a/js/interface/map-panel.js
+++ b/js/interface/map-panel.js
@@ -55,7 +55,19 @@ Fliplet.InteractiveMap.component('map-panel', {
       })
 
       window.filePickerProvider.then((result) => {
-        result.data[0].url = result.data[0].url + '?size=large'
+        let imageUrl = result.data[0].url
+
+        if (imageUrl.indexOf('?size=') === -1 && imageUrl.indexOf('&size=') === -1) {
+          const params = imageUrl.substring(1).split('?');
+          
+          if (params.length > 1) {
+            imageUrl = imageUrl + '&size=large'
+          } else {
+            imageUrl = imageUrl + '?size=large'
+          }
+        }
+
+        result.data[0].url = imageUrl
         this.image = result.data[0]
         this.onInputData(true)
         window.filePickerProvider = null

--- a/js/interface/map-panel.js
+++ b/js/interface/map-panel.js
@@ -55,6 +55,7 @@ Fliplet.InteractiveMap.component('map-panel', {
       })
 
       window.filePickerProvider.then((result) => {
+        result.data[0].url = result.data[0].url + '?size=large'
         this.image = result.data[0]
         this.onInputData(true)
         window.filePickerProvider = null


### PR DESCRIPTION
- Issue ref: https://github.com/Fliplet/fliplet-studio/issues/3972

### Info
When a very large image is added to the component we use the direct URL to show it, so users can place markers. However when we save the component settings, the media file gets added a `?size=large` by the backend which makes the image smaller than it used to be before saving.
This behaviour was messing up the initial coordinates set by the user.

### Fix
By adding the `?size=large` after getting the image information from the file picker provider we make sure the image is always the same size as the size after saving the component settings.

### Notes
Maybe this could be done in the backend so that the provider returns the URL with the `?size=large` from the start. cc @squallstar 