### PR TITLE
Allow users to select a marker by clicking on them

### DIFF
--- a/dist/add-markers.js
+++ b/dist/add-markers.js
@@ -566,35 +566,7 @@ Fliplet.InteractiveMap.component('add-markers', {
     onTapHandler: function onTapHandler(e) {
       var _this9 = this;
 
-      var markers = this.flPanZoomInstances[this.selectedMarkerData.map.id].markers.getAll(); // If user click somewhere on the map
-
-      if (!$(e.target).hasClass('marker')) {
-        // Find a marker
-        var markerId = undefined;
-
-        var markerIndex = _.findIndex(markers, function (marker) {
-          return marker.vars.id === _this9.selectedMarkerData.marker.id;
-        });
-
-        var markerFound = markers[markerIndex];
-
-        if (markerFound) {
-          markerId = markerFound.vars.id;
-        }
-
-        var clientRect = this.pzElement.get(0).getBoundingClientRect();
-        var elemPosX = clientRect.left;
-        var elemPosY = clientRect.top;
-        var center = e.center;
-        var x = (center.x - elemPosX) / (this.flPanZoomInstances[this.selectedMarkerData.map.id].getBaseZoom() * this.flPanZoomInstances[this.selectedMarkerData.map.id].getCurrentZoom());
-        var y = (center.y - elemPosY) / (this.flPanZoomInstances[this.selectedMarkerData.map.id].getBaseZoom() * this.flPanZoomInstances[this.selectedMarkerData.map.id].getCurrentZoom());
-        this.addMarkers(false, {
-          x: x,
-          y: y,
-          id: markerId,
-          existingMarker: markerFound
-        });
-      } else {
+      if ($(e.target).hasClass('marker')) {
         // If user clicks on a marker
         var markerName = $(e.target).data('name');
 
@@ -603,7 +575,36 @@ Fliplet.InteractiveMap.component('add-markers', {
         });
 
         this.setActiveMarker(_markerIndex, true);
+        return;
+      } // If user click somewhere on the map
+      // Find a marker
+
+
+      var markers = this.flPanZoomInstances[this.selectedMarkerData.map.id].markers.getAll();
+      var markerId = undefined;
+
+      var markerIndex = _.findIndex(markers, function (marker) {
+        return marker.vars.id === _this9.selectedMarkerData.marker.id;
+      });
+
+      var markerFound = markers[markerIndex];
+
+      if (markerFound) {
+        markerId = markerFound.vars.id;
       }
+
+      var clientRect = this.pzElement.get(0).getBoundingClientRect();
+      var elemPosX = clientRect.left;
+      var elemPosY = clientRect.top;
+      var center = e.center;
+      var x = (center.x - elemPosX) / (this.flPanZoomInstances[this.selectedMarkerData.map.id].getBaseZoom() * this.flPanZoomInstances[this.selectedMarkerData.map.id].getCurrentZoom());
+      var y = (center.y - elemPosY) / (this.flPanZoomInstances[this.selectedMarkerData.map.id].getBaseZoom() * this.flPanZoomInstances[this.selectedMarkerData.map.id].getCurrentZoom());
+      this.addMarkers(false, {
+        x: x,
+        y: y,
+        id: markerId,
+        existingMarker: markerFound
+      });
     },
     selectPinchMarker: function selectPinchMarker() {
       var _this10 = this;

--- a/dist/add-markers.js
+++ b/dist/add-markers.js
@@ -566,7 +566,7 @@ Fliplet.InteractiveMap.component('add-markers', {
     onTapHandler: function onTapHandler(e) {
       var _this9 = this;
 
-      var markers = this.flPanZoomInstances[this.selectedMarkerData.map.id].markers.getAll();
+      var markers = this.flPanZoomInstances[this.selectedMarkerData.map.id].markers.getAll(); // If user click somewhere on the map
 
       if (!$(e.target).hasClass('marker')) {
         // Find a marker
@@ -594,6 +594,15 @@ Fliplet.InteractiveMap.component('add-markers', {
           id: markerId,
           existingMarker: markerFound
         });
+      } else {
+        // If user clicks on a marker
+        var markerName = $(e.target).data('name');
+
+        var _markerIndex = _.findIndex(this.mappedMarkerData, function (marker) {
+          return marker.data.name == markerName;
+        });
+
+        this.setActiveMarker(_markerIndex, true);
       }
     },
     selectPinchMarker: function selectPinchMarker() {

--- a/js/interface/add-markers.js
+++ b/js/interface/add-markers.js
@@ -437,44 +437,42 @@ Fliplet.InteractiveMap.component('add-markers', {
       this.pzHandler.off('tap', this.onTapHandler)
     },
     onTapHandler(e) {
-      const markers = this.flPanZoomInstances[this.selectedMarkerData.map.id].markers.getAll()
-
-      
-
-      // If user click somewhere on the map
-      if (!$(e.target).hasClass('marker')) {
-        // Find a marker
-        let markerId = undefined
-        const markerIndex = _.findIndex(markers, (marker) => {
-          return marker.vars.id === this.selectedMarkerData.marker.id
-        })
-        const markerFound = markers[markerIndex]
-
-        if (markerFound) {
-          markerId = markerFound.vars.id
-        }
-
-        const clientRect = this.pzElement.get(0).getBoundingClientRect()
-        const elemPosX = clientRect.left
-        const elemPosY = clientRect.top
-        const center = e.center
-        const x = (center.x - elemPosX) / (this.flPanZoomInstances[this.selectedMarkerData.map.id].getBaseZoom() * this.flPanZoomInstances[this.selectedMarkerData.map.id].getCurrentZoom())
-        const y = (center.y - elemPosY) / (this.flPanZoomInstances[this.selectedMarkerData.map.id].getBaseZoom() * this.flPanZoomInstances[this.selectedMarkerData.map.id].getCurrentZoom())
-
-        this.addMarkers(false, {
-          x: x,
-          y: y,
-          id: markerId,
-          existingMarker: markerFound
-        })
-      } else {
+      if ($(e.target).hasClass('marker')) {
         // If user clicks on a marker
         const markerName = $(e.target).data('name')
         const markerIndex = _.findIndex(this.mappedMarkerData, (marker) => {
           return marker.data.name == markerName
         })
         this.setActiveMarker(markerIndex, true)
+        return
       }
+
+      // If user click somewhere on the map
+      // Find a marker
+      const markers = this.flPanZoomInstances[this.selectedMarkerData.map.id].markers.getAll()
+      let markerId = undefined
+      const markerIndex = _.findIndex(markers, (marker) => {
+        return marker.vars.id === this.selectedMarkerData.marker.id
+      })
+      const markerFound = markers[markerIndex]
+
+      if (markerFound) {
+        markerId = markerFound.vars.id
+      }
+
+      const clientRect = this.pzElement.get(0).getBoundingClientRect()
+      const elemPosX = clientRect.left
+      const elemPosY = clientRect.top
+      const center = e.center
+      const x = (center.x - elemPosX) / (this.flPanZoomInstances[this.selectedMarkerData.map.id].getBaseZoom() * this.flPanZoomInstances[this.selectedMarkerData.map.id].getCurrentZoom())
+      const y = (center.y - elemPosY) / (this.flPanZoomInstances[this.selectedMarkerData.map.id].getBaseZoom() * this.flPanZoomInstances[this.selectedMarkerData.map.id].getCurrentZoom())
+
+      this.addMarkers(false, {
+        x: x,
+        y: y,
+        id: markerId,
+        existingMarker: markerFound
+      })
     },
     selectPinchMarker() {
       // Remove any active marker

--- a/js/interface/add-markers.js
+++ b/js/interface/add-markers.js
@@ -439,6 +439,9 @@ Fliplet.InteractiveMap.component('add-markers', {
     onTapHandler(e) {
       const markers = this.flPanZoomInstances[this.selectedMarkerData.map.id].markers.getAll()
 
+      
+
+      // If user click somewhere on the map
       if (!$(e.target).hasClass('marker')) {
         // Find a marker
         let markerId = undefined
@@ -464,6 +467,13 @@ Fliplet.InteractiveMap.component('add-markers', {
           id: markerId,
           existingMarker: markerFound
         })
+      } else {
+        // If user clicks on a marker
+        const markerName = $(e.target).data('name')
+        const markerIndex = _.findIndex(this.mappedMarkerData, (marker) => {
+          return marker.data.name == markerName
+        })
+        this.setActiveMarker(markerIndex, true)
       }
     },
     selectPinchMarker() {


### PR DESCRIPTION
Issue ref: https://github.com/Fliplet/fliplet-studio/issues/4186

On the tap handler we were checking if the user was clicking on anything else on the map other than a marker to move the selected marker to that new location.

This just adds the ability to click on markers and all markers have the name as a `data` attribute which we can leverage to find the one to select on the right area.

![Screen Recording 2019-04-17 at 02 18 pm](https://user-images.githubusercontent.com/7046481/56290797-d8c04000-611b-11e9-862b-98d95ab98f9c.gif)
