### PR TITLE
Error handling

### DIFF
--- a/dist/build.js
+++ b/dist/build.js
@@ -191,9 +191,7 @@ Fliplet.Widget.instance('interactive-map', function (widgetData) {
           };
         }); // Check if markers have all the necessary info to be shown
 
-        var markersValidation = this.validateMarkers(newMarkerData);
-
-        if (!markersValidation) {
+        if (!this.validateMarkers(newMarkerData)) {
           Fliplet.UI.Toast({
             message: 'Some markers have missing information and they may not be shown.'
           });

--- a/dist/build.js
+++ b/dist/build.js
@@ -189,15 +189,54 @@ Fliplet.Widget.instance('interactive-map', function (widgetData) {
               positionY: marker.data[_this2.markerYPositionColumn]
             }
           };
-        });
+        }); // Check if markers have all the necessary info to be shown
+
+        var markersValidation = this.validateMarkers(newMarkerData);
+
+        if (!markersValidation) {
+          Fliplet.UI.Toast({
+            message: 'Some markers have missing information and they may not be shown.'
+          });
+        }
+
         return newMarkerData;
+      },
+      validateMarkers: function validateMarkers(markersData) {
+        if (!markersData && !markersData.length) {
+          return false;
+        }
+
+        var missingInfo = markersData.some(function (marker) {
+          var results = [];
+
+          for (var key in marker.data) {
+            if (!marker.data[key] || marker.data == '') {
+              results.push(false);
+              continue;
+            }
+          }
+
+          if (results.length) {
+            return false;
+          }
+
+          return true;
+        });
+        return missingInfo;
       },
       setupFlPanZoom: function setupFlPanZoom() {
         var _this3 = this;
 
         this.selectedMapData = this.maps[this.activeMap];
         this.selectedMarkerData = this.mappedMarkerData[this.activeMarker] ? this.mappedMarkerData[this.activeMarker].data : undefined;
-        this.selectedMarkerToggle = !!this.selectedMarkerData;
+        this.selectedMarkerToggle = !!this.selectedMarkerData; // Check if there is a map to initialize
+
+        if (!this.selectedMapData && !this.selectedMapData.id) {
+          return Fliplet.UI.Toast({
+            message: 'The map couldn\'t be found. Please make sure the maps are configured correctly.'
+          });
+        }
+
         this.pzElement = $('#map-' + this.selectedMapData.id);
 
         if (_.isEmpty(this.flPanZoomInstances) || !this.flPanZoomInstances[this.selectedMapData.id]) {

--- a/dist/build.js
+++ b/dist/build.js
@@ -472,18 +472,28 @@ Fliplet.Widget.instance('interactive-map', function (widgetData) {
           while (1) {
             switch (_context.prev = _context.next) {
               case 0:
-                if (!this.containsData) {
-                  _context.next = 3;
+                if (!(!this.markersDataSourceId || !this.markerNameColumn || !this.markerMapColumn || !this.markerTypeColumn || !this.markerXPositionColumn || !this.markerYPositionColumn)) {
+                  _context.next = 2;
                   break;
                 }
 
-                _context.next = 3;
+                return _context.abrupt("return", Fliplet.UI.Toast({
+                  message: 'The data source or data source columns are misconfigured.'
+                }));
+
+              case 2:
+                if (!this.containsData) {
+                  _context.next = 5;
+                  break;
+                }
+
+                _context.next = 5;
                 return this.init();
 
-              case 3:
+              case 5:
                 $(selector).removeClass('is-loading');
 
-              case 4:
+              case 6:
               case "end":
                 return _context.stop();
             }

--- a/dist/interface.js
+++ b/dist/interface.js
@@ -345,6 +345,22 @@ var app = new Vue({
           message: 'You need to select an image for each map you have created before continuing.'
         };
         return;
+      } // Check if DS info missing
+
+
+      if (!this.settings.markerMapColumn || !this.settings.markerNameColumn || !this.settings.markerTypeColumn || !this.settings.markerXPositionColumn || !this.settings.markerYPositionColumn) {
+        this.hasErrorOnSave = {
+          message: 'Your data source columns are misconfigured. Please make sure you selected a column for each field.'
+        };
+        return;
+      } // Check if DS info missing
+
+
+      if (!this.settings.markersDataSourceId) {
+        this.hasErrorOnSave = {
+          message: 'Your data source is misconfigured. Please make sure you selected and configured one.'
+        };
+        return;
       } // Mark 'isFromNew' as false
 
 

--- a/js/libs/build.js
+++ b/js/libs/build.js
@@ -326,6 +326,17 @@ Fliplet.Widget.instance('interactive-map', function(widgetData) {
       }
     },
     async mounted() {
+      if (!this.markersDataSourceId
+        || !this.markerNameColumn
+        || !this.markerMapColumn
+        || !this.markerTypeColumn
+        || !this.markerXPositionColumn
+        || !this.markerYPositionColumn) {
+        return Fliplet.UI.Toast({
+          message: 'The data source or data source columns are misconfigured.'
+        })
+      }
+
       if (this.containsData) {
         await this.init()
       }

--- a/js/libs/build.js
+++ b/js/libs/build.js
@@ -81,7 +81,38 @@ Fliplet.Widget.instance('interactive-map', function(widgetData) {
           }
         })
 
+        // Check if markers have all the necessary info to be shown
+        const markersValidation = this.validateMarkers(newMarkerData)
+        if (!markersValidation) {
+          Fliplet.UI.Toast({
+            message: 'Some markers have missing information and they may not be shown.'
+          })
+        }
+
         return newMarkerData
+      },
+      validateMarkers(markersData) {
+        if (!markersData && !markersData.length) {
+          return false
+        }
+
+        const missingInfo = markersData.some((marker) => {
+          const results = []
+          for (const key in marker.data) {
+            if (!marker.data[key] || marker.data == '') {
+              results.push(false)
+              continue
+            }
+          }
+
+          if (results.length) {
+            return false
+          }
+
+          return true
+        })
+
+        return missingInfo
       },
       setupFlPanZoom() {
         this.selectedMapData = this.maps[this.activeMap]
@@ -89,6 +120,13 @@ Fliplet.Widget.instance('interactive-map', function(widgetData) {
           ? this.mappedMarkerData[this.activeMarker].data
           : undefined
         this.selectedMarkerToggle = !!this.selectedMarkerData
+
+        // Check if there is a map to initialize
+        if (!this.selectedMapData && !this.selectedMapData.id) {
+          return Fliplet.UI.Toast({
+            message: 'The map couldn\'t be found. Please make sure the maps are configured correctly.'
+          })
+        }
 
         this.pzElement = $('#map-' + this.selectedMapData.id)
 

--- a/js/libs/build.js
+++ b/js/libs/build.js
@@ -82,8 +82,7 @@ Fliplet.Widget.instance('interactive-map', function(widgetData) {
         })
 
         // Check if markers have all the necessary info to be shown
-        const markersValidation = this.validateMarkers(newMarkerData)
-        if (!markersValidation) {
+        if (!this.validateMarkers(newMarkerData)) {
           Fliplet.UI.Toast({
             message: 'Some markers have missing information and they may not be shown.'
           })

--- a/js/libs/interface.js
+++ b/js/libs/interface.js
@@ -223,6 +223,26 @@ const app = new Vue({
         return
       }
 
+      // Check if DS info missing
+      if (!this.settings.markerMapColumn
+        || !this.settings.markerNameColumn
+        || !this.settings.markerTypeColumn
+        || !this.settings.markerXPositionColumn
+        || !this.settings.markerYPositionColumn) {
+        this.hasErrorOnSave = {
+          message: 'Your data source columns are misconfigured. Please make sure you selected a column for each field.'
+        }
+        return
+      }
+
+      // Check if DS info missing
+      if (!this.settings.markersDataSourceId) {
+        this.hasErrorOnSave = {
+          message: 'Your data source is misconfigured. Please make sure you selected and configured one.'
+        }
+        return
+      }
+
       // Mark 'isFromNew' as false
       this.maps.forEach((map) => {
         map.isFromNew = false


### PR DESCRIPTION
Error handling checks that came out from changes for https://github.com/Fliplet/fliplet-studio/issues/4186

With this changes it prevents the user from saving with missing crucial information, but if for some reason that information is still missing we do check in the `build` if that information is there and present to the user an error if it isn't, and we stop the rest of the code from running.

We also check:
1. if there's a map to initialize the PanZoom
2. if the markers have missing info - If they have the user will be informed but that doesn't break anything else it simply won't show the marker