### PR TITLE
Fixes #4323

### DIFF
--- a/dist/interface.js
+++ b/dist/interface.js
@@ -95,7 +95,7 @@
 
 "use strict";
 __webpack_require__.r(__webpack_exports__);
-var flInteractiveMapColumns = ['Name', 'Floor name', 'Marker style', 'Position X', 'Position Y'];
+var flInteractiveMapColumns = ['Name', 'Map name', 'Marker style', 'Position X', 'Position Y'];
 /* harmony default export */ __webpack_exports__["default"] = (flInteractiveMapColumns);
 
 /***/ }),

--- a/js/config/default-table.js
+++ b/js/config/default-table.js
@@ -1,6 +1,6 @@
 const flInteractiveMapColumns = [
   'Name',
-  'Floor name',
+  'Map name',
   'Marker style',
   'Position X',
   'Position Y'


### PR DESCRIPTION
Issue ref: https://github.com/Fliplet/fliplet-studio/issues/4323

Updated the default column name, this will prevent the code from thinking that column names were changed when the overlay is closed.