### PR TITLE
use .commit() correctly

### DIFF
--- a/dist/add-markers.js
+++ b/dist/add-markers.js
@@ -670,13 +670,9 @@ Fliplet.InteractiveMap.component('add-markers', {
       return newData;
     },
     saveToDataSource: function saveToDataSource() {
-      var data = this.cleanData();
-
-      if (!data || !data.length) {
-        return;
-      }
-
-      this.dataSourceConnection.commit(data);
+      var entries = this.cleanData();
+      var columns = this.markersDataSource.columns;
+      this.dataSourceConnection.commit(entries, columns);
     },
     addNewMarker: function addNewMarker(options) {
       var mapName;

--- a/js/interface/add-markers.js
+++ b/js/interface/add-markers.js
@@ -533,12 +533,9 @@ Fliplet.InteractiveMap.component('add-markers', {
       return newData
     },
     saveToDataSource() {
-      const data = this.cleanData()
-      if (!data || !data.length) {
-        return
-      }
-
-      this.dataSourceConnection.commit(data)
+      const entries = this.cleanData()
+      const columns = this.markersDataSource.columns
+      this.dataSourceConnection.commit(entries, columns)
     },
     addNewMarker(options) {
       let mapName


### PR DESCRIPTION
Issue ref: https://github.com/Fliplet/fliplet-studio/issues/4366

Before we were stopping the commit if there was no entries to be committed, because committing an empty array would ruin the table.

By looking through the code I discovered that `.commit()` also accepts a `columns` parameter, so by using it we can now commit empty array of entries without destroying the table columns.