### PR TITLE
Adds missing mediaFile reference

### DIFF
--- a/widget.json
+++ b/widget.json
@@ -48,6 +48,7 @@
     ]
   },
   "references": [
-    "markersDataSourceId:dataSource"
+    "markersDataSourceId:dataSource",
+    "maps.$.image.id:mediaFile"
   ]
 }


### PR DESCRIPTION
Ref: https://github.com/Fliplet/fliplet-studio/issues/4490

- Adding the missing `mediaFile` reference fixes the issue of missing images when cloning apps that contain the Interactive Graphics component.