### PR TITLE
The warning message now does not overlap the "Add a new map" button

### DIFF
--- a/css/interface.css
+++ b/css/interface.css
@@ -935,6 +935,7 @@ header .title-holder p {
   right: 0;
   padding: 15px;
   background-color: #eae9ec;
+  z-index: 2;
 }
 
 .errors-holder p {


### PR DESCRIPTION
@tonytlwu @squallstar 

## Issue
Fliplet/fliplet-studio#4163

## Description
Changed z-index of the warning message, so it is now bigger than the "Add a new map" button.

## Screenshots/screencasts
![Button demo](https://user-images.githubusercontent.com/52824207/63839068-39dc0800-c987-11e9-9bc3-f0dc013d7b02.gif)

## Backward compatibility
This change is fully backward compatible.