### PR TITLE
Fix IE behavior in Interactive map component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 *.map
+.history

--- a/css/interface.css
+++ b/css/interface.css
@@ -944,3 +944,22 @@ header .title-holder p {
 .is-loading .errors-holder {
   display: none;
 }
+
+@media screen and (-ms-high-contrast: none) {
+  .panel-chevron {
+    top: 11px;
+  }
+
+  .collapsed .panel-chevron {
+    top: -11px;
+  }
+  
+  .edit-marker-overlay-content {
+    left: 50%;
+    transform: translate(-50%, 0%);
+  }
+
+  .marker .active-state {
+    transform-origin: 80% 50%;
+  }
+}


### PR DESCRIPTION
@tonytlwu @squallstar 
## Issue
https://github.com/Fliplet/fliplet-studio/issues/4130
https://github.com/Fliplet/fliplet-studio/issues/4131
https://github.com/Fliplet/fliplet-studio/issues/4132

## Description
Centralized Marker Styles modal, centralized collapse/expand icon, centralized marker highlights.

## Screenshots/screencasts
![InteractiveMap-Fix-in-IE](https://user-images.githubusercontent.com/53430352/63862193-db2d8300-c9b4-11e9-9e46-d99d2af6ddf0.gif)


## Backward compatibility

This change is fully backward compatible.