### PR TITLE
When clicking cancel in a provider it doesn't close the entire widget.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 *.map
+.history

--- a/dist/map-panel.js
+++ b/dist/map-panel.js
@@ -130,6 +130,7 @@ Fliplet.InteractiveMap.component('map-panel', {
     openMapPicker: function openMapPicker() {
       var _this = this;
 
+      Fliplet.Widget.toggleCancelButton(false);
       var filePickerData = {
         selectFiles: this.image ? [this.image] : [],
         selectMultiple: false,
@@ -152,6 +153,7 @@ Fliplet.InteractiveMap.component('map-panel', {
         }
       });
       window.filePickerProvider.then(function (result) {
+        Fliplet.Widget.toggleCancelButton(true);
         var imageUrl = result.data[0].url;
         var pattern = /[?&]size=/;
 
@@ -178,6 +180,24 @@ Fliplet.InteractiveMap.component('map-panel', {
     Fliplet.InteractiveMap.off('maps-save', this.onInputData);
   }
 });
+
+Fliplet.Widget.onCancelRequest(function () {
+  var providersNames = [
+    'filePickerProvider',
+    'iconPickerProvider'
+  ];
+
+  _.each(providersNames, function (providerName) {
+    if (window[providerName]) {
+      window[providerName].close();
+      window[providerName] = null;
+    }
+  });
+
+  Fliplet.Widget.toggleSaveButton(true);
+  Fliplet.Widget.toggleCancelButton(true);
+  Fliplet.Studio.emit('widget-save-label-reset');
+})
 
 /***/ }),
 

--- a/dist/marker-panel.js
+++ b/dist/marker-panel.js
@@ -135,6 +135,7 @@ Fliplet.InteractiveMap.component('marker-panel', {
       var _this = this;
 
       this.icon = this.icon || '';
+      Fliplet.Widget.toggleCancelButton(false);
       window.iconPickerProvider = Fliplet.Widget.open('com.fliplet.icon-selector', {
         // Also send the data I have locally, so that
         // the interface gets repopulated with the same stuff
@@ -146,19 +147,11 @@ Fliplet.InteractiveMap.component('marker-panel', {
           }
         }
       });
-      window.addEventListener('message', function (event) {
-        if (event.data === 'cancel-button-pressed') {
-          window.iconPickerProvider.close();
-          window.iconPickerProvider = null;
-          Fliplet.Studio.emit('widget-save-label-update', {
-            text: 'Save'
-          });
-        }
-      });
       Fliplet.Studio.emit('widget-save-label-update', {
         text: 'Select & Save'
       });
       window.iconPickerProvider.then(function (data) {
+        Fliplet.Widget.toggleCancelButton(true);
         if (data.data) {
           _this.icon = data.data.icon;
         }


### PR DESCRIPTION
@tonytlwu @squallstar 
## Issue
https://github.com/Fliplet/fliplet-studio/issues/3990

## Description
When we are clicking the cancel button we closing only called provider, not an entire widget.

## Screenshots/screencasts
![issue-3990](https://user-images.githubusercontent.com/53430352/64101693-1219e500-cd77-11e9-811c-b5b6b926b541.gif)


## Backward compatibility

This change is fully backward compatible.
