### PR TITLE
Now padding in file-picker provider is correct

### DIFF
--- a/css/interface.css
+++ b/css/interface.css
@@ -5,10 +5,6 @@ body,
   overflow: hidden;
 }
 
-.fl-widget-provider {
-  padding: 15px;
-}
-
 main {
   padding: 15px;
   height: 100%;


### PR DESCRIPTION
@tonytlwu @squallstar 

## Issue
Fliplet/fliplet-studio#4947

## Description
Removed padding from the file-picker provider.

## Screenshots/screencasts
Before:
<img width="378" alt="Padding demo 2" src="https://user-images.githubusercontent.com/52824207/64336217-1cd9b180-cfe5-11e9-8f2a-7b6c85e305c7.png">

After:
<img width="378" alt="Padding demo 1" src="https://user-images.githubusercontent.com/52824207/64336216-1cd9b180-cfe5-11e9-81a9-fc2450491c80.png">

## Backward compatibility
This change is fully backward compatible.