### PR TITLE
The marker icons are updated when user closes marker panel

### DIFF
--- a/dist/add-markers.js
+++ b/dist/add-markers.js
@@ -428,7 +428,8 @@ Fliplet.InteractiveMap.component('add-markers', {
       });
     },
     toggleEditMarkerOverlay: function toggleEditMarkerOverlay() {
-      this.showEditMarkerOverlay = !!!this.showEditMarkerOverlay;
+      this.showEditMarkerOverlay = !this.showEditMarkerOverlay;
+      this.reloadData();
     },
     setupFlPanZoom: function setupFlPanZoom() {
       var _this7 = this;

--- a/dist/add-markers.js
+++ b/dist/add-markers.js
@@ -1670,7 +1670,7 @@ try {
 /*! no static exports found */
 /***/ (function(module, exports, __webpack_require__) {
 
-module.exports = __webpack_require__(/*! /Users/hcarneiro/Repos/Fliplet/fliplet-widget-interactive-floorplan/js/interface/add-markers.js */"./js/interface/add-markers.js");
+module.exports = __webpack_require__(/*! /Users/maksym/Desktop/Upplabs/Fliplet/interactive graphics/fliplet-widget-interactive-map/js/interface/add-markers.js */"./js/interface/add-markers.js");
 
 
 /***/ })

--- a/dist/build.js
+++ b/dist/build.js
@@ -1363,7 +1363,7 @@ try {
 /*! no static exports found */
 /***/ (function(module, exports, __webpack_require__) {
 
-module.exports = __webpack_require__(/*! /Users/hcarneiro/Repos/Fliplet/fliplet-widget-interactive-floorplan/js/libs/build.js */"./js/libs/build.js");
+module.exports = __webpack_require__(/*! /Users/maksym/Desktop/Upplabs/Fliplet/interactive graphics/fliplet-widget-interactive-map/js/libs/build.js */"./js/libs/build.js");
 
 
 /***/ })

--- a/dist/core.js
+++ b/dist/core.js
@@ -133,7 +133,7 @@ Fliplet.InteractiveMap = function () {
 /*! no static exports found */
 /***/ (function(module, exports, __webpack_require__) {
 
-module.exports = __webpack_require__(/*! /Users/hcarneiro/Repos/Fliplet/fliplet-widget-interactive-floorplan/js/libs/core.js */"./js/libs/core.js");
+module.exports = __webpack_require__(/*! /Users/maksym/Desktop/Upplabs/Fliplet/interactive graphics/fliplet-widget-interactive-map/js/libs/core.js */"./js/libs/core.js");
 
 
 /***/ })

--- a/dist/interface.js
+++ b/dist/interface.js
@@ -2856,7 +2856,7 @@ var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_RESULT__;/**!
 /*! no static exports found */
 /***/ (function(module, exports, __webpack_require__) {
 
-module.exports = __webpack_require__(/*! /Users/hcarneiro/Repos/Fliplet/fliplet-widget-interactive-floorplan/js/libs/interface.js */"./js/libs/interface.js");
+module.exports = __webpack_require__(/*! /Users/maksym/Desktop/Upplabs/Fliplet/interactive graphics/fliplet-widget-interactive-map/js/libs/interface.js */"./js/libs/interface.js");
 
 
 /***/ })

--- a/dist/map-panel.js
+++ b/dist/map-panel.js
@@ -130,7 +130,6 @@ Fliplet.InteractiveMap.component('map-panel', {
     openMapPicker: function openMapPicker() {
       var _this = this;
 
-      Fliplet.Widget.toggleCancelButton(false);
       var filePickerData = {
         selectFiles: this.image ? [this.image] : [],
         selectMultiple: false,
@@ -153,7 +152,6 @@ Fliplet.InteractiveMap.component('map-panel', {
         }
       });
       window.filePickerProvider.then(function (result) {
-        Fliplet.Widget.toggleCancelButton(true);
         var imageUrl = result.data[0].url;
         var pattern = /[?&]size=/;
 
@@ -181,24 +179,6 @@ Fliplet.InteractiveMap.component('map-panel', {
   }
 });
 
-Fliplet.Widget.onCancelRequest(function () {
-  var providersNames = [
-    'filePickerProvider',
-    'iconPickerProvider'
-  ];
-
-  _.each(providersNames, function (providerName) {
-    if (window[providerName]) {
-      window[providerName].close();
-      window[providerName] = null;
-    }
-  });
-
-  Fliplet.Widget.toggleSaveButton(true);
-  Fliplet.Widget.toggleCancelButton(true);
-  Fliplet.Studio.emit('widget-save-label-reset');
-})
-
 /***/ }),
 
 /***/ 4:
@@ -208,7 +188,7 @@ Fliplet.Widget.onCancelRequest(function () {
 /*! no static exports found */
 /***/ (function(module, exports, __webpack_require__) {
 
-module.exports = __webpack_require__(/*! /Users/hcarneiro/Repos/Fliplet/fliplet-widget-interactive-floorplan/js/interface/map-panel.js */"./js/interface/map-panel.js");
+module.exports = __webpack_require__(/*! /Users/maksym/Desktop/Upplabs/Fliplet/interactive graphics/fliplet-widget-interactive-map/js/interface/map-panel.js */"./js/interface/map-panel.js");
 
 
 /***/ })

--- a/dist/marker-panel.js
+++ b/dist/marker-panel.js
@@ -139,7 +139,6 @@ Fliplet.InteractiveMap.component('marker-panel', {
       var _this = this;
 
       this.icon = this.icon || '';
-      Fliplet.Widget.toggleCancelButton(false);
       window.iconPickerProvider = Fliplet.Widget.open('com.fliplet.icon-selector', {
         // Also send the data I have locally, so that
         // the interface gets repopulated with the same stuff
@@ -151,11 +150,19 @@ Fliplet.InteractiveMap.component('marker-panel', {
           }
         }
       });
+      window.addEventListener('message', function (event) {
+        if (event.data === 'cancel-button-pressed') {
+          window.iconPickerProvider.close();
+          window.iconPickerProvider = null;
+          Fliplet.Studio.emit('widget-save-label-update', {
+            text: 'Save'
+          });
+        }
+      });
       Fliplet.Studio.emit('widget-save-label-update', {
         text: 'Select & Save'
       });
       window.iconPickerProvider.then(function (data) {
-        Fliplet.Widget.toggleCancelButton(true);
         if (!data.data.icon) {
           _this.emptyIconNotification = true;
         } else {
@@ -220,7 +227,7 @@ Fliplet.InteractiveMap.component('marker-panel', {
 /*! no static exports found */
 /***/ (function(module, exports, __webpack_require__) {
 
-module.exports = __webpack_require__(/*! /Users/hcarneiro/Repos/Fliplet/fliplet-widget-interactive-floorplan/js/interface/marker-panel.js */"./js/interface/marker-panel.js");
+module.exports = __webpack_require__(/*! /Users/maksym/Desktop/Upplabs/Fliplet/interactive graphics/fliplet-widget-interactive-map/js/interface/marker-panel.js */"./js/interface/marker-panel.js");
 
 
 /***/ })

--- a/js/interface/add-markers.js
+++ b/js/interface/add-markers.js
@@ -193,7 +193,7 @@ Fliplet.InteractiveMap.component('add-markers', {
     },
     deleteMarker(index) {
       const markerId = this.mappedMarkerData[index].id
-        
+
       if (markerId) {
         this.flPanZoomInstances[this.selectedMarkerData.map.id].markers.remove(markerId, { keepInDom: false })
       }
@@ -314,7 +314,8 @@ Fliplet.InteractiveMap.component('add-markers', {
       })
     },
     toggleEditMarkerOverlay() {
-      this.showEditMarkerOverlay = !!!this.showEditMarkerOverlay
+      this.showEditMarkerOverlay = !this.showEditMarkerOverlay;
+      this.reloadData();
     },
     setupFlPanZoom() {
       const mapName = this.mappedMarkerData.length

--- a/js/interface/marker-panel.js
+++ b/js/interface/marker-panel.js
@@ -28,6 +28,10 @@ Fliplet.InteractiveMap.component('marker-panel', {
     isFromNew: {
       type: Boolean,
       default: true
+    },
+    emptyIconNotification: {
+      type: Boolean,
+      default: false
     }
   },
   methods: {
@@ -66,14 +70,18 @@ Fliplet.InteractiveMap.component('marker-panel', {
       })
 
       window.iconPickerProvider.then((data) => {
-        if (data.data) {
-          this.icon = data.data.icon
+        if (!data.data.icon) {
+          this.emptyIconNotification = true;
+        } else {
+          this.icon = data.data.icon;
+          this.emptyIconNotification = false;
         }
-        this.onInputData()
-        window.iconPickerProvider = null
-        Fliplet.Studio.emit('widget-save-label-reset')
-        return Promise.resolve()
-      })
+
+        this.onInputData();
+        window.iconPickerProvider = null;
+        Fliplet.Studio.emit('widget-save-label-reset');
+        return Promise.resolve();
+      });
     }
   },
   created() {


### PR DESCRIPTION
@tonytlwu @squallstar 

## Issue
Fliplet/fliplet-studio#4820

## Description
Added the reloadData method on clicking the marker panel close button.

## Screenshots/screencasts
![Update markers demo](https://user-images.githubusercontent.com/52824207/64602949-4ec58c00-d3c8-11e9-9745-f5b552a46eb9.gif)

## Backward compatibility
This change is fully backward compatible.