### PR TITLE
Input background color is now dark in all browsers 

### DIFF
--- a/css/build.css
+++ b/css/build.css
@@ -433,6 +433,7 @@ body.fl-with-bottom-menu [data-widget-package^="com.fliplet.interactive-map"] {
 }
 
 .interactive-map-overlay-search-holder .form-control {
+  background-color: #333333;
   color: #ffffff;
   border-radius: 40px;
   box-shadow: none;


### PR DESCRIPTION
@tonytlwu @squallstar 

## Issue
Fliplet/fliplet-studio#5001

## Description
Added background color to search input.

## Screenshots/screencasts
<img width="334" alt="Interactive demo" src="https://user-images.githubusercontent.com/52824207/66137032-1dc22b00-e605-11e9-9bc1-dce4533b4e46.png">

## Backward compatibility
This change is fully backward compatible.