### PR TITLE
Placeholder height is set to 100%

### DIFF
--- a/css/build.css
+++ b/css/build.css
@@ -37,6 +37,10 @@ body.fl-with-bottom-menu [data-widget-package^="com.fliplet.interactive-map"] {
 }
 
 .widget-not-configured {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  height: 100%;
   padding: 20px;
   text-align: center;
   background: rgba(51,51,51,0.1);


### PR DESCRIPTION
@tonytlwu @squallstar 

## Issue
Fliplet/fliplet-studio#5152

## Description
Added styling according to Hugo's comments in the issue.

## Screenshots/screencasts
<img width="751" alt="interactive demo" src="https://user-images.githubusercontent.com/52824207/67990831-be752c00-fc3f-11e9-8051-d894b3562829.png">

## Backward compatibility
This change is fully backward compatible.