### PR TITLE
create marker's data source bound appId

### DIFF
--- a/dist/interface.js
+++ b/dist/interface.js
@@ -134,6 +134,7 @@ var app = new Vue({
   el: selector,
   data: function data() {
     return {
+	  appId: Fliplet.Env.get('appId'),
       appName: Fliplet.Env.get('appName'),
       organizationId: Fliplet.Env.get('organizationId'),
       defaultColumns: _config_default_table__WEBPACK_IMPORTED_MODULE_3__["default"],
@@ -164,7 +165,8 @@ var app = new Vue({
       var name = "".concat(this.appName, " - Map Markers");
       return Fliplet.DataSources.create({
         name: name,
-        organizationId: this.organizationId,
+		organizationId: this.organizationId,
+		appId: this.appId,
         columns: this.defaultColumns,
         bundle: true
       }).then(function (ds) {

--- a/js/libs/interface.js
+++ b/js/libs/interface.js
@@ -18,6 +18,7 @@ const app = new Vue({
   el: selector,
   data() {
     return {
+      appId: Fliplet.Env.get('appId'),
       appName: Fliplet.Env.get('appName'),
       organizationId: Fliplet.Env.get('organizationId'),
       defaultColumns: flInteractiveMapColumns,
@@ -47,6 +48,7 @@ const app = new Vue({
       return Fliplet.DataSources.create({
         name: name,
         organizationId: this.organizationId,
+        appId: this.appId,
         columns: this.defaultColumns,
         bundle: true
       }).then((ds) => {
@@ -263,7 +265,7 @@ const app = new Vue({
           message:"One of your maps doesn't have a valid name. Please input a valid name to save the configuration."
         })
       }
-      
+
       return
     }
 


### PR DESCRIPTION
ref https://github.com/Fliplet/fliplet-studio/issues/5147

---

The Data Source created by the Interactive Map could not be used in the app when used as a webapp because of missing permissions: the dataSource does not seem to be in use by the app nor have explicit permissions assigned.