### PR TITLE
Icons and buttons are no longer cropped in the IE 11

### DIFF
--- a/css/interface.css
+++ b/css/interface.css
@@ -965,4 +965,8 @@ header .title-holder p {
   .marker .active-state {
     transform-origin: 80% 50%;
   }
+
+  #interactive-map-app header p {
+    flex: none !important;
+  }
 }


### PR DESCRIPTION
@sofiiakvasnevska 
## Issue
https://github.com/Fliplet/fliplet-studio/issues/4964

## Description
Icons and buttons are no more cropped in the IE 11

## Screenshots/screencasts
![image](https://user-images.githubusercontent.com/53430352/71673421-724e8100-2d81-11ea-80c7-23c4cabe87c4.png)

## Backward compatibility

This change is fully backward compatible.