### PR TITLE
Allow interactive map work correctly when it placed in the accordion.

### DIFF
--- a/css/build.css
+++ b/css/build.css
@@ -318,7 +318,7 @@ body.fl-with-bottom-menu [data-widget-package^="com.fliplet.interactive-map"] {
 
 .interactive-maps-search-overlay,
 .interactive-maps-overlay {
-  position: fixed;
+  position: absolute;
   background-color: #333333;
   color: #ffffff;
   z-index: 100;


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/4807

## Description
Allow interactive map work correctly when it placed in the accordion.

## Screenshots/screencasts
https://share.getcloudapp.com/Z4u5P7J4

## Backward compatibility

This change is fully backward compatible.