### PR TITLE
Opening Markers Styles dropdown works correctly

### DIFF
--- a/css/interface.css
+++ b/css/interface.css
@@ -544,6 +544,7 @@ header .title-holder p {
 
 .markers-ui-holder {
   display: flex;
+  flex: 1;
   flex-flow: column nowrap;
   min-height: 44px;
   margin: 0;


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/5731

## Description
Added flex 1 to the container that contains markers.
## Screenshots/screencasts
![interactive](https://user-images.githubusercontent.com/52824207/77159319-c843e280-6aad-11ea-8d49-821ef8134e25.PNG)

## Backward compatibility
This change is fully backward compatible.