### PR TITLE
Allow users to select an icon in the marker styles menu

### DIFF
--- a/dist/add-markers.js
+++ b/dist/add-markers.js
@@ -1760,9 +1760,7 @@ try {
 /*! no static exports found */
 /***/ (function(module, exports, __webpack_require__) {
 
-
-module.exports = __webpack_require__(/*! C:\Max\Upplabs\Fliplet\interactive graphics\fliplet-widget-interactive-map\js\interface\add-markers.js */"./js/interface/add-markers.js");
-
+module.exports = __webpack_require__(/*! C:\Users\Yaroslav\Desktop\Fliplet\fliplet-widget-interactive-map\js\interface\add-markers.js */"./js/interface/add-markers.js");
 
 
 /***/ })

--- a/dist/build.js
+++ b/dist/build.js
@@ -1393,8 +1393,7 @@ try {
 /*! no static exports found */
 /***/ (function(module, exports, __webpack_require__) {
 
-module.exports = __webpack_require__(/*! C:\Max\Upplabs\Fliplet\interactive graphics\fliplet-widget-interactive-map\js\libs\build.js */"./js/libs/build.js");
-
+module.exports = __webpack_require__(/*! C:\Users\Yaroslav\Desktop\Fliplet\fliplet-widget-interactive-map\js\libs\build.js */"./js/libs/build.js");
 
 
 /***/ })

--- a/dist/core.js
+++ b/dist/core.js
@@ -133,9 +133,7 @@ Fliplet.InteractiveMap = function () {
 /*! no static exports found */
 /***/ (function(module, exports, __webpack_require__) {
 
-
-module.exports = __webpack_require__(/*! C:\Max\Upplabs\Fliplet\interactive graphics\fliplet-widget-interactive-map\js\libs\core.js */"./js/libs/core.js");
-
+module.exports = __webpack_require__(/*! C:\Users\Yaroslav\Desktop\Fliplet\fliplet-widget-interactive-map\js\libs\core.js */"./js/libs/core.js");
 
 
 /***/ })

--- a/dist/interface.js
+++ b/dist/interface.js
@@ -2874,8 +2874,7 @@ var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_RESULT__;/**!
 /*! no static exports found */
 /***/ (function(module, exports, __webpack_require__) {
 
-module.exports = __webpack_require__(/*! C:\Max\Upplabs\Fliplet\interactive graphics\fliplet-widget-interactive-map\js\libs\interface.js */"./js/libs/interface.js");
-
+module.exports = __webpack_require__(/*! C:\Users\Yaroslav\Desktop\Fliplet\fliplet-widget-interactive-map\js\libs\interface.js */"./js/libs/interface.js");
 
 
 /***/ })

--- a/dist/map-panel.js
+++ b/dist/map-panel.js
@@ -304,10 +304,10 @@ Fliplet.Widget.onCancelRequest(function () {
     if (window[providerName]) {
       window[providerName].close();
       window[providerName] = null;
+      Fliplet.Widget.toggleSaveButton(providerName !== 'iconPickerProvider');
     }
   });
 
-  Fliplet.Widget.toggleSaveButton(true);
   Fliplet.Widget.toggleCancelButton(true);
   Fliplet.Studio.emit('widget-save-label-reset');
 });
@@ -347,9 +347,7 @@ module.exports = _defineProperty;
 /*! no static exports found */
 /***/ (function(module, exports, __webpack_require__) {
 
-
-module.exports = __webpack_require__(/*! C:\Max\Upplabs\Fliplet\interactive graphics\fliplet-widget-interactive-map\js\interface\map-panel.js */"./js/interface/map-panel.js");
-
+module.exports = __webpack_require__(/*! C:\Users\Yaroslav\Desktop\Fliplet\fliplet-widget-interactive-map\js\interface\map-panel.js */"./js/interface/map-panel.js");
 
 
 /***/ })

--- a/dist/marker-panel.js
+++ b/dist/marker-panel.js
@@ -150,8 +150,17 @@ Fliplet.InteractiveMap.component('marker-panel', {
         data: this.icon,
         // Events fired from the provider
         onEvent: function onEvent(event, data) {
-          if (event === 'interface-validate') {
-            Fliplet.Widget.toggleSaveButton(data.isValid === true);
+          switch (event) {
+            case 'interface-validate':
+              Fliplet.Widget.toggleSaveButton(data.isValid === true);
+              break;
+
+            case 'icon-clicked':
+              Fliplet.Widget.toggleSaveButton(data.isSelected);
+              break;
+
+            default:
+              break;
           }
         }
       });
@@ -172,6 +181,7 @@ Fliplet.InteractiveMap.component('marker-panel', {
 
         window.iconPickerProvider = null;
         Fliplet.Studio.emit('widget-save-label-reset');
+        Fliplet.Widget.toggleSaveButton(false);
         return Promise.resolve();
       });
     }
@@ -225,9 +235,7 @@ Fliplet.InteractiveMap.component('marker-panel', {
 /*! no static exports found */
 /***/ (function(module, exports, __webpack_require__) {
 
-
-module.exports = __webpack_require__(/*! C:\Max\Upplabs\Fliplet\interactive graphics\fliplet-widget-interactive-map\js\interface\marker-panel.js */"./js/interface/marker-panel.js");
-
+module.exports = __webpack_require__(/*! C:\Users\Yaroslav\Desktop\Fliplet\fliplet-widget-interactive-map\js\interface\marker-panel.js */"./js/interface/marker-panel.js");
 
 
 /***/ })

--- a/js/interface/map-panel.js
+++ b/js/interface/map-panel.js
@@ -197,10 +197,11 @@ Fliplet.Widget.onCancelRequest(function () {
     if (window[providerName]) {
       window[providerName].close()
       window[providerName] = null
+
+      Fliplet.Widget.toggleSaveButton(providerName !== 'iconPickerProvider')
     }
   })
 
-  Fliplet.Widget.toggleSaveButton(true)
   Fliplet.Widget.toggleCancelButton(true)
   Fliplet.Studio.emit('widget-save-label-reset')
 })

--- a/js/interface/marker-panel.js
+++ b/js/interface/marker-panel.js
@@ -54,8 +54,15 @@ Fliplet.InteractiveMap.component('marker-panel', {
         data: this.icon,
         // Events fired from the provider
         onEvent: (event, data) => {
-          if (event === 'interface-validate') {
-            Fliplet.Widget.toggleSaveButton(data.isValid === true)
+          switch (event) {
+            case 'interface-validate': 
+              Fliplet.Widget.toggleSaveButton(data.isValid === true)
+              break
+            case 'icon-clicked':
+              Fliplet.Widget.toggleSaveButton(data.isSelected);
+              break
+            default:
+              break
           }
         }
       })
@@ -76,6 +83,7 @@ Fliplet.InteractiveMap.component('marker-panel', {
         this.onInputData();
         window.iconPickerProvider = null
         Fliplet.Studio.emit('widget-save-label-reset')
+        Fliplet.Widget.toggleSaveButton(false)
         return Promise.resolve()
       });
     }


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/6232

## Description
Allow users to select an icon in the marker styles menu

## Screenshots/screencasts
https://share.getcloudapp.com/nOu8NlOz

## Backward compatibility

This change is fully backward compatible.

## Reviewers 
@upplabs-alex-levchenko @MaksymShokin 

## Notes
For this fix to work we need to merge this [PR](https://github.com/Fliplet/fliplet-widget-icon-selector/pull/2) first.