### PR TITLE
[Fix] Show correct error message when the user doesn't have permissions to the Data Source.

### DIFF
--- a/dist/add-markers.js
+++ b/dist/add-markers.js
@@ -1760,7 +1760,8 @@ try {
 /*! no static exports found */
 /***/ (function(module, exports, __webpack_require__) {
 
-module.exports = __webpack_require__(/*! C:\Max\Upplabs\Fliplet\interactive graphics\fliplet-widget-interactive-map\js\interface\add-markers.js */"./js/interface/add-markers.js");
+module.exports = __webpack_require__(/*! C:\Users\Yaroslav\Desktop\Fliplet\fliplet-widget-interactive-map\js\interface\add-markers.js */"./js/interface/add-markers.js");
+
 
 /***/ })
 

--- a/dist/build.js
+++ b/dist/build.js
@@ -459,7 +459,7 @@ Fliplet.Widget.instance('interactive-map', function (widgetData) {
               label: 'Details',
               action: function action() {
                 Fliplet.UI.Toast({
-                  html: error.message || error
+                  html: error.message || Fliplet.parseError(error)
                 });
               }
             }]
@@ -1394,6 +1394,7 @@ try {
 /***/ (function(module, exports, __webpack_require__) {
 
 module.exports = __webpack_require__(/*! C:\Users\Yaroslav\Desktop\Fliplet\fliplet-widget-interactive-map\js\libs\build.js */"./js/libs/build.js");
+
 
 /***/ })
 

--- a/dist/core.js
+++ b/dist/core.js
@@ -133,8 +133,7 @@ Fliplet.InteractiveMap = function () {
 /*! no static exports found */
 /***/ (function(module, exports, __webpack_require__) {
 
-
-module.exports = __webpack_require__(/*! C:\Max\Upplabs\Fliplet\interactive graphics\fliplet-widget-interactive-map\js\libs\core.js */"./js/libs/core.js");
+module.exports = __webpack_require__(/*! C:\Users\Yaroslav\Desktop\Fliplet\fliplet-widget-interactive-map\js\libs\core.js */"./js/libs/core.js");
 
 
 /***/ })

--- a/dist/interface.js
+++ b/dist/interface.js
@@ -2876,6 +2876,7 @@ var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_RESULT__;/**!
 
 module.exports = __webpack_require__(/*! C:\Users\Yaroslav\Desktop\Fliplet\fliplet-widget-interactive-map\js\libs\interface.js */"./js/libs/interface.js");
 
+
 /***/ })
 
 /******/ });

--- a/dist/map-panel.js
+++ b/dist/map-panel.js
@@ -347,8 +347,7 @@ module.exports = _defineProperty;
 /*! no static exports found */
 /***/ (function(module, exports, __webpack_require__) {
 
-
-module.exports = __webpack_require__(/*! C:\Max\Upplabs\Fliplet\interactive graphics\fliplet-widget-interactive-map\js\interface\map-panel.js */"./js/interface/map-panel.js");
+module.exports = __webpack_require__(/*! C:\Users\Yaroslav\Desktop\Fliplet\fliplet-widget-interactive-map\js\interface\map-panel.js */"./js/interface/map-panel.js");
 
 
 /***/ })

--- a/dist/marker-panel.js
+++ b/dist/marker-panel.js
@@ -235,7 +235,7 @@ Fliplet.InteractiveMap.component('marker-panel', {
 /*! no static exports found */
 /***/ (function(module, exports, __webpack_require__) {
 
-module.exports = __webpack_require__(/*! C:\Max\Upplabs\Fliplet\interactive graphics\fliplet-widget-interactive-map\js\interface\marker-panel.js */"./js/interface/marker-panel.js");
+module.exports = __webpack_require__(/*! C:\Users\Yaroslav\Desktop\Fliplet\fliplet-widget-interactive-map\js\interface\marker-panel.js */"./js/interface/marker-panel.js");
 
 
 /***/ })

--- a/js/libs/build.js
+++ b/js/libs/build.js
@@ -333,7 +333,7 @@ Fliplet.Widget.instance('interactive-map', function(widgetData) {
                   label: 'Details',
                   action: function () {
                     Fliplet.UI.Toast({
-                      html: error.message || error
+                      html: error.message || Fliplet.parseError(error)
                     });
                   }
                 }


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/6548

## Description
Show correct error message when the user doesn't have permissions to the Data Source.

## Screenshots/screencasts
![inter map error msg](https://user-images.githubusercontent.com/53430352/84146637-a92d6f00-aa64-11ea-9ea9-0662c3ff7f0e.png)

## Backward compatibility
This change is fully backward compatible.

## Reviewers
@upplabs-alex-levchenko